### PR TITLE
fix-handle-error-statuses-from-saleor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "saleor-app"
-version = "0.2.10"
+version = "0.2.11"
 description = "Saleor app framework"
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 

--- a/src/saleor_app/saleor/client.py
+++ b/src/saleor_app/saleor/client.py
@@ -16,6 +16,7 @@ class SaleorClient:
         self.session = aiohttp.ClientSession(
             base_url=saleor_url,
             headers=headers,
+            raise_for_status=True,
             timeout=ClientTimeout(total=timeout),
         )
 
@@ -45,4 +46,4 @@ class SaleorClient:
                 logger.error("Error when executing a GraphQL call to Saleor")
                 logger.debug(str(exc))
                 raise exc
-            return response_data["data"]
+            return response_data.get("data")


### PR DESCRIPTION
This is to handle cases where bad responses from Saleor do not include the `data` key. Right now the framework assumes the key will always be there which is not the case. 